### PR TITLE
Fix 500 Internal Server Errors under high traffic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 DATABASE_URL="mongodb://mongo:27017/myTestDatabase?replicaSet=rs0"
 ION_CLIENT_SECRET=ION_OAUTH_CLIENT_SECRET_HERE
 ION_CLIENT_ID=ION_OAUTH_CLIENT_SECRET_HERE
+SESSION_COOKIE_SECRET=REPLACE_WITH_RANDOM_32_BYTE_SECRET
 
 # Database url may be changed if using cloud mongodb over local
 # to test prefixer, you need PREFIXER_API_URL (look up how google sheets api works)

--- a/src/lib/api/authorize.ts
+++ b/src/lib/api/authorize.ts
@@ -1,8 +1,20 @@
-import { PrismaClient } from '@prisma/client';
 import { NextApiRequest, NextApiResponse } from 'next';
 import {db} from '@/lib/db/db'
+import { readSessionCookie } from '@/lib/api/sessionCookie'
 
-export const authorize = async (req: NextApiRequest, res: NextApiResponse, admin=false) => {
+const parseJsonResponse = async (response: Response) => {
+  if (!response.ok) return null
+  const contentType = response.headers.get('content-type') || ''
+  if (!contentType.includes('application/json')) return null
+  return response.json()
+}
+
+export const authorize = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  admin=false,
+  options: { requireProfile?: boolean } = {}
+) => {
   let authorization = null
   if(!authorization) authorization = req.headers.authorization
   if(!authorization && req.cookies.auth) {
@@ -10,16 +22,48 @@ export const authorize = async (req: NextApiRequest, res: NextApiResponse, admin
     if(auth) authorization = `Bearer ${auth.access_token}`
   }
   req.headers.authorization = authorization
+
+  const session = readSessionCookie(req)
+  if (session) {
+    const user = await db.user.findFirst({
+      where: {
+        id: session.userId
+      }
+    })
+    const authorized = Boolean(user && (!admin || user.admin))
+    if (user && admin && !user.admin) {
+      return {
+        authorized: false,
+        user,
+        profileBody: null
+      }
+    }
+    if (authorized && !options.requireProfile) {
+      return {
+        authorized,
+        user,
+        profileBody: null
+      }
+    }
+  }
+
+  if (!authorization) {
+    return {
+      authorized: false,
+      user: null,
+      profileBody: null
+    }
+  }
   
   const profileRes = await fetch('https://ion.tjhsst.edu/api/profile', {headers: {
     'Authorization': authorization
   }})
-  let profileBody = await profileRes.json()
-  let authorized = Boolean(profileBody.id)
+  const profileBody = await parseJsonResponse(profileRes)
+  let authorized = Boolean(profileBody?.id)
   
   let user = await db.user.findFirst({
     where: {
-      ionId: String(profileBody.id)
+      ionId: String(profileBody?.id)
     }
   })
   

--- a/src/lib/api/sessionCookie.ts
+++ b/src/lib/api/sessionCookie.ts
@@ -1,0 +1,68 @@
+import crypto from 'crypto'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { setCookie } from '@/lib/api/setCookie'
+
+const SESSION_COOKIE_NAME = 'session'
+const SESSION_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
+
+export type SessionPayload = {
+  userId: string
+  ionId: string
+  admin: boolean
+  issuedAt: number
+}
+
+const getSessionSecret = () => process.env.SESSION_COOKIE_SECRET || ''
+
+const base64UrlEncode = (value: string) =>
+  Buffer.from(value).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+
+const base64UrlDecode = (value: string) => {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padding = normalized.length % 4 === 0 ? '' : '='.repeat(4 - (normalized.length % 4))
+  return Buffer.from(normalized + padding, 'base64').toString('utf8')
+}
+
+const signPayload = (payload: string, secret: string) =>
+  crypto.createHmac('sha256', secret).update(payload).digest('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+
+export const createSessionCookieValue = (payload: SessionPayload) => {
+  const secret = getSessionSecret()
+  if (!secret) return null
+  const payloadString = JSON.stringify(payload)
+  const encodedPayload = base64UrlEncode(payloadString)
+  const signature = signPayload(encodedPayload, secret)
+  return `${encodedPayload}.${signature}`
+}
+
+export const readSessionCookie = (req: NextApiRequest) => {
+  const secret = getSessionSecret()
+  if (!secret) return null
+  const raw = req.cookies?.[SESSION_COOKIE_NAME]
+  if (!raw) return null
+  const [encodedPayload, signature] = raw.split('.')
+  if (!encodedPayload || !signature) return null
+  const expected = signPayload(encodedPayload, secret)
+  const expectedBuffer = Buffer.from(expected)
+  const signatureBuffer = Buffer.from(signature)
+  if (expectedBuffer.length !== signatureBuffer.length) return null
+  if (!crypto.timingSafeEqual(expectedBuffer, signatureBuffer)) return null
+  try {
+    const decoded = base64UrlDecode(encodedPayload)
+    return JSON.parse(decoded) as SessionPayload
+  } catch {
+    return null
+  }
+}
+
+export const setSessionCookie = (res: NextApiResponse, payload: SessionPayload) => {
+  const value = createSessionCookieValue(payload)
+  if (!value) return
+  setCookie(res, SESSION_COOKIE_NAME, value, {
+    secure: true,
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: SESSION_COOKIE_MAX_AGE
+  })
+}

--- a/src/lib/api/setCookie.ts
+++ b/src/lib/api/setCookie.ts
@@ -7,7 +7,7 @@ export const setCookie = (
   value: unknown,
   options: CookieSerializeOptions = {}
 ) => {
-  const stringValue = JSON.stringify(value)
+  const stringValue = typeof value === 'string' ? value : JSON.stringify(value)
   if(typeof options.maxAge === 'number'){
     options.expires = new Date(Date.now() + options.maxAge*1000)
   }

--- a/src/pages/api/auth/ion/callback.ts
+++ b/src/pages/api/auth/ion/callback.ts
@@ -1,7 +1,15 @@
 import { parsePath } from './../../../../lib/api/parsePath';
 import { setCookie } from '@/lib/api/setCookie';
+import { setSessionCookie } from '@/lib/api/sessionCookie';
 import { db } from '@/lib/db/db';
 import { NextApiRequest, NextApiResponse } from 'next';
+
+const parseJsonResponse = async (response: Response) => {
+  if (!response.ok) return null
+  const contentType = response.headers.get('content-type') || ''
+  if (!contentType.includes('application/json')) return null
+  return response.json()
+}
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { code } = req.query
@@ -23,7 +31,11 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       'redirect_uri': `${baseUrl}/api/auth/ion/callback`
     })
   })
-  const tokenBody = await tokenRes.json()
+  const tokenBody = await parseJsonResponse(tokenRes)
+  if (!tokenBody?.access_token) {
+    res.redirect(302, baseUrl + '/')
+    return
+  }
 
   setCookie(res, 'auth', tokenBody, {
     secure: true,
@@ -38,7 +50,11 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       'Authorization': `Bearer ${tokenBody.access_token}`
     }
   })
-  const profileBody = await profileRes.json()
+  const profileBody = await parseJsonResponse(profileRes)
+  if (!profileBody?.id) {
+    res.redirect(302, baseUrl + '/')
+    return
+  }
   
   let user = await db.user.findFirst({
     where: {
@@ -47,6 +63,12 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   })
 
   if(user){
+    setSessionCookie(res, {
+      userId: user.id,
+      ionId: String(profileBody.id),
+      admin: user.admin,
+      issuedAt: Date.now()
+    })
     res.redirect(302, baseUrl + (route.startsWith('/404') ? '/' : route))
   } else {
     res.redirect(302, baseUrl + '/signup')

--- a/src/pages/api/user/index.ts
+++ b/src/pages/api/user/index.ts
@@ -1,9 +1,16 @@
 import { authorize } from '@/lib/api/authorize';
+import { setSessionCookie } from '@/lib/api/sessionCookie';
 import { db } from '@/lib/db/db';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  const { authorized, profileBody, user } = await authorize(req, res)
+  const requireProfile = req.method === 'POST'
+  const { authorized, profileBody, user } = await authorize(
+    req,
+    res,
+    false,
+    { requireProfile }
+  )
   if (!authorized) return res.status(401).send(null)
 
   try {
@@ -50,6 +57,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
           profilePicUrl: profilePicUrl,
           profilePicData: picData
         }
+      })
+
+      setSessionCookie(res, {
+        userId: user.id,
+        ionId: String(profileBody.id),
+        admin: user.admin,
+        issuedAt: Date.now()
       })
 
       return res.status(200).json({


### PR DESCRIPTION
500 Internal Server Errors under high traffic for 8th pd attendance were likely caused by Ion Oauth rate limiting us.

Here, three things are added:

- JSON-parse guardrails (so no 500 error)
- Signed session cookie (so user data is stored in a signed session cookie, thus reducing the load on authorize.ts to keep checking ion oauth API)
- Authorize short-circuit to stop if the user is not logged in (don't attempt an ion api and identity lookup with no authorization code) or if the session cookie exists, in which case important user data (userId, IonId, admin, issuedAt) stored in the signed cookie is used for DB lookup.